### PR TITLE
Change XMLHttpRequest error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function json(url, obj, headers, fn){
   if (3 == arguments.length) fn = headers, headers = {};
 
   var req = new XMLHttpRequest;
-  req.onerror = fn;
+  req.onerror = error;
   req.onload = done;
   req.open('POST', url, true);
   for (var k in headers) req.setRequestHeader(k, headers[k]);
@@ -70,7 +70,19 @@ function json(url, obj, headers, fn){
   function done(){
     // sometimes IE returns 1223 when it should be 204
     // see http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
-    /^(20\d|1223)$/.test(req.status) ? fn(null, req) : fn(req);
+    if (/^(20\d|1223)$/.test(req.status)) {
+      fn(null, req)
+    } else {
+      var err = new Error("Request wasn't successful")
+      err.req = req;
+      fn(err);
+    }
+  }
+
+  function error(evt){
+    var err = new Error("A network error ocurred");
+    err.evt = evt;
+    fn(err);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -62,13 +62,15 @@ function json(url, obj, headers, fn){
 
   var req = new XMLHttpRequest;
   req.onerror = fn;
-  req.onreadystatechange = done;
+  req.onload = done;
   req.open('POST', url, true);
   for (var k in headers) req.setRequestHeader(k, headers[k]);
   req.send(JSON.stringify(obj));
 
   function done(){
-    if (4 == req.readyState) return fn(null, req);
+    // sometimes IE returns 1223 when it should be 204
+    // see http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
+    /^(20\d|1223)$/.test(req.status) ? fn(null, req) : fn(req);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -71,17 +71,14 @@ function json(url, obj, headers, fn){
     // sometimes IE returns 1223 when it should be 204
     // see http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
     if (/^(20\d|1223)$/.test(req.status)) {
-      fn(null, req)
-    } else {
-      var err = new Error("Request wasn't successful")
-      err.req = req;
-      fn(err);
+      return fn(null, req)
     }
+    fn(new Error("Request wasn't successful"), req);
   }
 
-  function error(evt){
+  function error(event){
     var err = new Error("A network error ocurred");
-    err.evt = evt;
+    err.event = event;
     fn(err);
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('send-json', function(){
       var headers = { 'Content-Type': 'application/json' };
       send.json(url, [1, 2, 3], headers, function(err, req){
         assert(err);
-        assert(typeof err.evt === "object");
+        assert(typeof err.event === "object");
         done();
       });
     })
@@ -38,8 +38,8 @@ describe('send-json', function(){
       var headers = { 'Content-Type': 'application/json' };
       send.json(url, [1, 2, 3], headers, function(err, req){
         assert(err);
-        assert(typeof err.req === "object");
-        assert(err.req.status === 404);
+        assert(typeof req === "object");
+        assert(req.status === 404);
         done();
       });
     })

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('send-json', function(){
       var headers = { 'Content-Type': 'application/json' };
       send.json(url, [1, 2, 3], headers, function(err, req){
         assert(err);
-        assert(err.status === undefined);
+        assert(typeof err.evt === "object");
         done();
       });
     })
@@ -38,7 +38,8 @@ describe('send-json', function(){
       var headers = { 'Content-Type': 'application/json' };
       send.json(url, [1, 2, 3], headers, function(err, req){
         assert(err);
-        assert(err.status === 404);
+        assert(typeof err.req === "object");
+        assert(err.req.status === 404);
         done();
       });
     })

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,28 @@ describe('send-json', function(){
         done();
       });
     })
+
+    it('should invoke the callback with an error when connection is refused', function(done){
+      if ('xhr' != send.type) return done();
+      var url = protocol() + '//localhost:4567/data';
+      var headers = { 'Content-Type': 'application/json' };
+      send.json(url, [1, 2, 3], headers, function(err, req){
+        assert(err);
+        assert(err.status === undefined);
+        done();
+      });
+    })
+
+    it('should invoke the callback with an error when the request does not succeed', function(done){
+      if ('xhr' != send.type) return done();
+      var url = protocol() + '//localhost:3001/not-found';
+      var headers = { 'Content-Type': 'application/json' };
+      send.json(url, [1, 2, 3], headers, function(err, req){
+        assert(err);
+        assert(err.status === 404);
+        done();
+      });
+    })
   })
 
   describe('#base64', function(){


### PR DESCRIPTION
- Listen for 'load' event instead of 'readystatechange' because the
  later can be triggered along with the 'error' event.
- Check the response status code, and invoke the callback with an
  error argument when it is not in the 20x range.
